### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/actions-allow-list.yml
+++ b/.github/workflows/actions-allow-list.yml
@@ -34,7 +34,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       # if using Enterprise, use the `/enterprises/<enterprise-slug>` endpoint


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret